### PR TITLE
ci: bump Actions, Python 3.14, ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,28 +16,31 @@ name: CI - docker-pihole
   workflow_dispatch:
 
 env:
-  python_version: 3.12
+  python_version: "3.14"
 
 jobs:
   lint:
     name: Ansible & YAML lint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.12"
+          python-version: ${{ env.python_version }}
 
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip
-          pip install "ansible-core==2.20.1" "ansible-lint==25.12.1" "yamllint==1.37.1"
+          python -m pip install \
+            "ansible-core==2.20.5" \
+            "ansible-lint==26.4.0" \
+            "yamllint==1.38.0"
 
       - name: Install Galaxy roles and collections
         run: ./scripts/install-ansible-collections.sh
@@ -57,22 +60,22 @@ jobs:
   # This role does not run --check in CI (needs Docker / target host); use tests/local-test.yml locally.
   ansible-tests-ubuntu:
     name: Ansible syntax & dry-run
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: lint
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.12"
+          python-version: ${{ env.python_version }}
 
       - name: Install Ansible
         run: |
           python -m pip install --upgrade pip
-          pip install ansible
+          python -m pip install "ansible-core==2.20.5"
 
       - name: Show Ansible version
         run: ansible --version

--- a/tasks/deploypi.yml
+++ b/tasks/deploypi.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create pihole directory
-  file:
+  ansible.builtin.file:
     path: "{{ pihole_compose_dir }}"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
@@ -8,7 +8,7 @@
     mode: '0755'
 
 - name: Deploy Docker Compose file
-  template:
+  ansible.builtin.template:
     src: docker-compose.yml.j2
     dest: "{{ pihole_compose_dir }}/docker-compose.yml"
     owner: "{{ ansible_user }}"
@@ -35,19 +35,19 @@
         replace: 'DNSStubListener=no'
 
     - name: Disable DNSStubListener in systemd-resolved configuration
-      lineinfile:
+      ansible.builtin.lineinfile:
         path: /etc/systemd/resolved.conf
         regexp: '^#?DNSStubListener='
         line: 'DNSStubListener=no'
         backup: true
 
     - name: Remove /etc/resolv.conf if it exists
-      file:
+      ansible.builtin.file:
         path: /etc/resolv.conf
         state: absent
 
     - name: Create symlink for resolv.conf
-      file:
+      ansible.builtin.file:
         src: /run/systemd/resolve/resolv.conf
         dest: /etc/resolv.conf
         state: link

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -24,7 +24,7 @@
   when: pihole_environment_variables.REV_SERVER
 
 - name: Check if DHCP is enabled
-  set_fact:
+  ansible.builtin.set_fact:
     pihole_dhcp_enabled: "{{ pihole_environment_variables.DHCP_ACTIVE | lower == 'true' }}"
 
 - name: Allow DHCP port in the firewall (if enabled)

--- a/tasks/pre.yml
+++ b/tasks/pre.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create Pi-hole configuration directories
-  file:
+  ansible.builtin.file:
     path: '{{ dir_loc }}/{{ item }}'
     state: directory
     owner: root

--- a/tasks/verify.yml
+++ b/tasks/verify.yml
@@ -13,13 +13,14 @@
     success_msg: "Pi-hole container is running."
 
 - name: DNS test for google.com via local Pi-hole
-  command: dig +short google.com @127.0.0.1
+  ansible.builtin.command:
+    cmd: dig +short google.com @127.0.0.1
   register: dns_test_google
   changed_when: false
   failed_when: dns_test_google.stdout == ""
 
 - name: Assert google.com result looks like valid IPv4
-  assert:
+  ansible.builtin.assert:
     that:
       - dns_test_google.stdout_lines | length > 0
       - dns_test_google.stdout_lines | select(


### PR DESCRIPTION
Pin actions/checkout@v6.0.2 and actions/setup-python@v6.2.0. Use Python 3.14 and ubuntu-latest; pip pins remain at current PyPI releases.

Made-with: Cursor