### PR TITLE
EL/Vagrant: align docker_manage_iptables, fix NAT discover path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,10 @@ dir_loc: '/opt/pihole'
 pihole_compose_dir: "{{ dir_loc }}"
 firewall_deploy: false
 
-# EL Docker NAT fallback after compose (see tasks/redhat_nat_fallback.yml); match ansible-pihole docker role.
-docker_manage_iptables: true
+# Must stay aligned with roles/docker/defaults — same variable is used in both roles; last role used to
+# win in defaults, so a literal `true` here overwrote the docker role and broke EL/Vagrant bridge egress.
+# EL Docker NAT fallback after compose (see tasks/redhat_nat_fallback.yml).
+docker_manage_iptables: "{{ not (vagrant_env | default(false) | bool) }}"
 docker_el_nat_fallback: true
 
 # Opt-in Rocky/EL lab mode: stop firewalld, install bind-utils (dig on the host), run Pi-hole

--- a/tasks/deploypi.yml
+++ b/tasks/deploypi.yml
@@ -60,7 +60,8 @@
         state: restarted
       failed_when: false
 
-# restart docker to ensure IP tables are valid after install
+# Bounce Docker so daemon picks up /etc/docker/daemon.json (e.g. iptables: false) before we bring up
+# project networks. EL bridge egress still needs the nft MASQ block after `compose up` (redhat_nat_fallback).
 - name: Restart docker
   ansible.builtin.service:
     name: docker

--- a/tasks/redhat_nat_fallback.yml
+++ b/tasks/redhat_nat_fallback.yml
@@ -11,7 +11,15 @@
     lock_timeout: 300
   when: ansible_facts['os_family'] == 'RedHat'
 
-# Subnet JSON parsing lives in files/docker_network_subnet_print.py (short shell lines for lint).
+# Copy the helper to the *guest* (controller role_path in a remote shell is wrong for Galaxy installs).
+# Same logic as files/docker_network_subnet_print.py; roles/docker uses an inline -c to avoid a copy.
+- name: Install Docker network subnet JSON helper on target
+  ansible.builtin.copy:
+    src: docker_network_subnet_print.py
+    dest: "{{ pihole_compose_dir }}/docker_network_subnet_print.py"
+    mode: "0755"
+  when: ansible_facts['os_family'] == 'RedHat'
+
 - name: Discover Docker IPv4 subnets (dynamic)
   ansible.builtin.shell:
     cmd: |
@@ -19,6 +27,7 @@
       if ! command -v docker >/dev/null 2>&1; then
         exit 0
       fi
+      H='{{ pihole_compose_dir }}/docker_network_subnet_print.py'
       declare -A seen=()
       while read -r id; do
         [ -z "${id:-}" ] && continue
@@ -26,8 +35,7 @@
           [ -z "${cidr:-}" ] && continue
           [[ "$cidr" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]] || continue
           seen["$cidr"]=1
-        done < <(docker network inspect "$id" 2>/dev/null |
-          python3 "{{ role_path }}/files/docker_network_subnet_print.py" 2>/dev/null || true)
+        done < <(docker network inspect "$id" 2>/dev/null | python3 "$H" 2>/dev/null || true)
       done < <(docker network ls -q 2>/dev/null || true)
       for k in "${!seen[@]}"; do
         printf '%s\n' "$k"


### PR DESCRIPTION
- defaults: set docker_manage_iptables to match vagrant/EL pattern (no override of the docker role default).
- redhat_nat_fallback: copy subnet helper to pihole_compose_dir on the guest and run it there (avoids controller role_path on remote).
- deploypi: clarify why Docker is restarted before compose + NAT.

Made-with: Cursor