### PR TITLE
EL/Vagrant: fix bridge egress NAT fallback + iptables var alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,73 @@
 Role Name
 =========
 
-A simple role to allow for deployment pihole docker container to a host
+A simple role to deploy the Pi-hole Docker container to a host.
 
 Requirements
 ------------
 
-Docker needs to be installed on the host
+- Docker must be installed on the host.
 
 Role Variables
 --------------
 
-    dir_loc: '/opt/pihole' # installation location of the files for the container and the compose file
-    firewall_deploy: true # set to false if you do not want or use firewalld
+Common variables:
+
+    # Persistent data + docker-compose.yml location
+    dir_loc: "/opt/pihole"
+    pihole_compose_dir: "/opt/pihole"
+
+    # Container settings
+    pihole_image: "pihole/pihole:latest"
+    pihole_container_name: "pihole"
+    timezone: "Europe/London"
+
+    # Published ports (only when NOT using host networking)
+    webport_http: "80"
+    webport_https: "443"
+
+    # Host firewall (firewalld on RedHat family)
+    firewall_deploy: false
     firewall_itmes:
       - dns
       - http
       - https
-    pihole_image: "pihole/pihole:2024.07.0" # current version of Pihole, set to latest if you want the newist version at all times
-    timezone: "Europe/London" # Select your local timezone
-    firewall_deploy: true # will ensure firewalld is install and configured
-    pihole_container_name: pihole
-    webport_http: '80' # Port for HTTP-Requests to Webinterface.
-    webport_https: '443' # Port for HTTPS-DoH Requests.
 
-    For full detials about the containers vars please see https://github.com/pi-hole/docker-pi-hole
+Pi-hole container env vars:
+
+    # Full list: https://github.com/pi-hole/docker-pi-hole
     pihole_environment_variables:
       TZ: "{{ timezone }}"
       FTLCONF_MAXDBDAYS: "180"
-      WEBPASSWORD: 'Intranet' # example value, change it and better use ansible-vault
-      PIHOLE_DNS_: "1.1.1.1;2606:4700:4700::1111"
-      REV_SERVER: "true"
-      REV_SERVER_CIDR: "192.168.56.0/24"
-      REV_SERVER_TARGET: "192.168.56.1"
-      REV_SERVER_DOMAIN: "test"
+      FTLCONF_webserver_api_password: "change-me"
+      FTLCONF_dns_listeningMode: "all"
       DHCP_ACTIVE: false
-      PIHOLE_DOMAIN: 'test'
-      WEBTHEME: "default-darker"
+
+### Rocky / EL + Vagrant bridge notes
+
+On EL9+ guests (e.g. Rocky Linux) it is common to run Docker with `iptables: false` (or have missing xtables
+matches). In that configuration Docker will not add MASQUERADE rules, and containers may not have internet
+egress until NAT is configured.
+
+This role supports that with an opt-in nftables masquerade fallback that discovers Docker network subnets
+and applies NAT rules after `docker compose up` creates the project networks.
+
+Relevant variables:
+
+    # Must match the same variable used by the docker role.
+    # When false on EL, the role will apply nftables NAT fallback after compose.
+    docker_manage_iptables: "{{ not (vagrant_env | default(false) | bool) }}"
+    docker_el_nat_fallback: true
+
+For lab debugging you can bypass the bridge entirely:
+
+    # Runs the Pi-hole container in the host network namespace (no bridge NAT).
+    pihole_use_host_network: false
+
+Optional Rocky debug mode:
+
+    # Stops firewalld, installs dig on the host, and relaxes container confinement (lab only).
+    pihole_rocky_network_debug: false
 
 Dependencies
 ------------
@@ -50,28 +81,18 @@ Simple example playbook is as follows
 
     - hosts: dns-servers
       vars:
-        dir_loc: '/opt/pihole'
-        firewall_deploy: true
-        firewall_itmes:
-          - dns
-          - http
-          - https
-        pihole_image: "pihole/pihole:2024.07.0"
+        pihole_compose_dir: "/opt/pihole"
+        dir_loc: "/opt/pihole"
+        firewall_deploy: false
+        pihole_image: "pihole/pihole:latest"
         timezone: "Europe/London"
-        firewall_deploy: true # will ensure firewalld is install and configured
-        pihole_container_name: pihole
+        pihole_container_name: "pihole"
         pihole_environment_variables:
           TZ: "{{ timezone }}"
           FTLCONF_MAXDBDAYS: "180"
-          WEBPASSWORD: 'Intranet' # example value, change it and better use ansible-vault
-          PIHOLE_DNS_: "1.1.1.1;2606:4700:4700::1111"
-          REV_SERVER: "true"
-          REV_SERVER_CIDR: "192.168.56.0/24"
-          REV_SERVER_TARGET: "192.168.56.1"
-          REV_SERVER_DOMAIN: "test"
+          FTLCONF_webserver_api_password: "change-me"
+          FTLCONF_dns_listeningMode: "all"
           DHCP_ACTIVE: false
-          PIHOLE_DOMAIN: 'test'
-          WEBTHEME: "default-darker"
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,10 @@ dir_loc: '/opt/pihole'
 pihole_compose_dir: "{{ dir_loc }}"
 firewall_deploy: false
 
-# EL Docker NAT fallback after compose (see tasks/redhat_nat_fallback.yml); match ansible-pihole docker role.
-docker_manage_iptables: true
+# Must stay aligned with roles/docker/defaults — same variable is used in both roles; last role used to
+# win in defaults, so a literal `true` here overwrote the docker role and broke EL/Vagrant bridge egress.
+# EL Docker NAT fallback after compose (see tasks/redhat_nat_fallback.yml).
+docker_manage_iptables: "{{ not (vagrant_env | default(false) | bool) }}"
 docker_el_nat_fallback: true
 
 # Opt-in Rocky/EL lab mode: stop firewalld, install bind-utils (dig on the host), run Pi-hole

--- a/tasks/deploypi.yml
+++ b/tasks/deploypi.yml
@@ -60,7 +60,8 @@
         state: restarted
       failed_when: false
 
-# restart docker to ensure IP tables are valid after install
+# Bounce Docker so daemon picks up /etc/docker/daemon.json (e.g. iptables: false) before we bring up
+# project networks. EL bridge egress still needs the nft MASQ block after `compose up` (redhat_nat_fallback).
 - name: Restart docker
   ansible.builtin.service:
     name: docker

--- a/tasks/redhat_nat_fallback.yml
+++ b/tasks/redhat_nat_fallback.yml
@@ -11,7 +11,15 @@
     lock_timeout: 300
   when: ansible_facts['os_family'] == 'RedHat'
 
-# Subnet JSON parsing lives in files/docker_network_subnet_print.py (short shell lines for lint).
+# Copy the helper to the *guest* (controller role_path in a remote shell is wrong for Galaxy installs).
+# Same logic as files/docker_network_subnet_print.py; roles/docker uses an inline -c to avoid a copy.
+- name: Install Docker network subnet JSON helper on target
+  ansible.builtin.copy:
+    src: docker_network_subnet_print.py
+    dest: "{{ pihole_compose_dir }}/docker_network_subnet_print.py"
+    mode: "0755"
+  when: ansible_facts['os_family'] == 'RedHat'
+
 - name: Discover Docker IPv4 subnets (dynamic)
   ansible.builtin.shell:
     cmd: |
@@ -19,6 +27,7 @@
       if ! command -v docker >/dev/null 2>&1; then
         exit 0
       fi
+      H='{{ pihole_compose_dir }}/docker_network_subnet_print.py'
       declare -A seen=()
       while read -r id; do
         [ -z "${id:-}" ] && continue
@@ -26,8 +35,7 @@
           [ -z "${cidr:-}" ] && continue
           [[ "$cidr" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]] || continue
           seen["$cidr"]=1
-        done < <(docker network inspect "$id" 2>/dev/null |
-          python3 "{{ role_path }}/files/docker_network_subnet_print.py" 2>/dev/null || true)
+        done < <(docker network inspect "$id" 2>/dev/null | python3 "$H" 2>/dev/null || true)
       done < <(docker network ls -q 2>/dev/null || true)
       for k in "${!seen[@]}"; do
         printf '%s\n' "$k"


### PR DESCRIPTION
## Summary
- Align `docker_manage_iptables` default with the Vagrant/EL pattern so the pihole role does not override the docker role and accidentally re-enable Docker iptables behavior.
- Fix EL NAT fallback subnet discovery by copying the helper to the guest and running it from a real target path (avoids using controller-only `role_path` inside a remote shell).
- Minor deploypi clarification around Docker restart ordering.

## Test plan
- [ ] On Rocky/Vagrant with `vagrant_env: true` and Docker `iptables: false`, run converge and confirm container egress (gravity update) works.
- [ ] Confirm `tasks/redhat_nat_fallback.yml` creates nft masquerade rules for actual compose network subnets.

Made with [Cursor](https://cursor.com)