### PR TITLE
Merge dev: Molecule Docker local tests

### DIFF
--- a/molecule/ansible.cfg
+++ b/molecule/ansible.cfg
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT-0
+# Used only when ANSIBLE_CONFIG points here (molecule/default/molecule.yml).
+# Quiets molecule_docker 2.1 create/destroy playbooks (non-boolean `when:`) on Ansible 2.19+.
+[defaults]
+collections_path = ./.ansible/collections
+inject_facts_as_vars = False
+deprecation_warnings = False
+allow_broken_conditionals = True

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT-0
+---
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+  roles:
+    - role: docker-pihole

--- a/molecule/default/group_vars/all.yml
+++ b/molecule/default/group_vars/all.yml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT-0
+---
+ansible_python_interpreter: auto_silent
+# ansible.cfg sets inject_facts_as_vars=false; set connection user explicitly for owner/group in tasks.
+ansible_user: root
+
+# Paths must exist on the instance; same paths are used for compose bind mounts.
+dir_loc: /var/tmp/molecule-docker-pihole
+pihole_compose_dir: "{{ dir_loc }}"
+pihole_container_name: molecule-pihole
+# Published host ports (role defaults are not auto-loaded for standalone verify play).
+webport_http: "80"
+webport_https: "443"
+firewall_deploy: false
+# Geerlingguy systemd test image has no systemd-resolved package; skip stub-DNS tweaks.
+pihole_configure_systemd_resolved: false
+
+# Narrow test surface inside the container.
+pihole_image: pihole/pihole:latest
+pihole_environment_variables:
+  TZ: UTC
+  FTLCONF_webserver_api_password: molecule-test
+  FTLCONF_dns_listeningMode: ALL
+  DHCP_ACTIVE: "false"
+  REV_SERVER: "false"
+  REV_SERVER_CIDR: "192.168.56.0/24"
+  REV_SERVER_TARGET: "192.168.56.1"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT-0
+---
+# Collections are installed via scripts/install-ansible-collections.sh or pip bundles; skip Galaxy here
+# (avoids molecule treating requirements.yml as a roles file).
+dependency:
+  name: galaxy
+  enabled: false
+
+driver:
+  name: docker
+
+platforms:
+  # Systemd + privileged Docker-in-Docker so deploypi.yml can manage the docker service and run Pi-hole.
+  - name: instance
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
+    pre_build_image: true
+    privileged: true
+    cgroupns_mode: host
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+
+provisioner:
+  name: ansible
+  env:
+    # molecule/ansible.cfg: deprecation off + allow_broken for molecule_docker 2.1 create/destroy playbooks.
+    ANSIBLE_CONFIG: "${MOLECULE_PROJECT_DIRECTORY}/molecule/ansible.cfg"
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/..:${MOLECULE_PROJECT_DIRECTORY}"
+
+verifier:
+  name: ansible
+
+scenario:
+  name: default
+  # deploypi.yml always restarts docker; skip idempotence. Lint runs in CI (ansible-lint).
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT-0
+---
+# Privileged Docker-in-Docker: overlay graph driver often fails nested; vfs works (slower, test-only).
+- name: Prepare instance (Docker engine + tools for the role)
+  hosts: all
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Install Docker, Compose v2, and verify tooling
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - curl
+          - docker.io
+          - docker-compose-v2
+          - dnsutils
+          - python3-docker
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: Stop Docker before reconfiguring storage (if running)
+      ansible.builtin.service:
+        name: docker
+        state: stopped
+      failed_when: false
+
+    - name: Remove Docker graph dir so vfs migration is clean (ephemeral Molecule instance only)
+      ansible.builtin.file:
+        path: /var/lib/docker
+        state: absent
+
+    - name: Configure Docker to use vfs storage driver for nested containers
+      ansible.builtin.copy:
+        dest: /etc/docker/daemon.json
+        content: |
+          {"storage-driver": "vfs"}
+        mode: '0644'
+
+    - name: Ensure Docker daemon is enabled and running
+      ansible.builtin.service:
+        name: docker
+        state: started
+        enabled: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT-0
+---
+- name: Verify
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Include role verify tasks (container + DNS checks)
+      ansible.builtin.include_tasks: "{{ lookup('ansible.builtin.env', 'MOLECULE_PROJECT_DIRECTORY') }}/tasks/verify.yml"
+
+    - name: Pi-hole admin UI responds over HTTP (published webport)
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ webport_http | int }}/admin/"
+        method: GET
+        follow_redirects: all
+        return_content: true
+        status_code: [200, 301, 302, 303, 307, 308]
+      register: pihole_admin_http
+      retries: 15
+      delay: 4
+      until: (pihole_admin_http.status | default(-1) | int) in [200, 301, 302, 303, 307, 308]
+
+    - name: Assert Pi-hole web UI markup is present
+      ansible.builtin.assert:
+        that:
+          - >-
+            'Pi-hole' in (pihole_admin_http.content | default(''))
+            or 'pi-hole' in ((pihole_admin_http.content | default('')) | lower)
+        fail_msg: >-
+          HTTP admin on port {{ webport_http }} did not return expected Pi-hole UI
+          (HTTP {{ pihole_admin_http.status | default('?') }}).
+        success_msg: Pi-hole admin UI is reachable over HTTP on port {{ webport_http }}.
+
+    - name: Pi-hole admin UI over HTTPS (optional; published HTTPS webport)
+      ansible.builtin.uri:
+        url: "https://127.0.0.1:{{ webport_https | int }}/admin/"
+        method: GET
+        follow_redirects: all
+        validate_certs: false
+        return_content: true
+        status_code: [200, 301, 302, 303, 307, 308]
+      register: pihole_admin_https
+      failed_when: false
+      changed_when: false
+
+    - name: Assert Pi-hole HTTPS admin when TLS is listening
+      ansible.builtin.assert:
+        that:
+          - (pihole_admin_https.status | int) in [200, 301, 302, 303, 307, 308]
+          - >-
+            'Pi-hole' in (pihole_admin_https.content | default(''))
+            or 'pi-hole' in ((pihole_admin_https.content | default('')) | lower)
+        success_msg: Pi-hole admin UI is reachable over HTTPS on port {{ webport_https }}.
+      when: pihole_admin_https.status is defined


### PR DESCRIPTION
## Summary

Brings **dev** up to date with **master**, including the new Molecule Docker scenario merged in #19.

### Included from dev
- **Molecule** default scenario (Docker driver): local end-to-end test with Pi-hole role, DNS verify, and HTTP/HTTPS `/admin/` checks.

## Checklist
- [ ] CI green on this PR before merge.


Made with [Cursor](https://cursor.com)