### PR TITLE
feat(ci): auto-tag and Ansible Galaxy publish

### DIFF
--- a/.github/actions/import-galaxy-role/action.yml
+++ b/.github/actions/import-galaxy-role/action.yml
@@ -1,0 +1,38 @@
+---
+name: Import role to Ansible Galaxy
+description: Import this repository as a legacy role on Ansible Galaxy
+
+inputs:
+  role-name:
+    description: Galaxy role name
+    required: false
+    default: docker-pihole
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+
+    - name: Install Ansible
+      shell: bash
+      run: python -m pip install 'ansible-core>=2.20,<2.21'
+
+    - name: Import role into Ansible Galaxy
+      shell: bash
+      env:
+        GALAXY_API_KEY: ${{ env.GALAXY_API_KEY }}
+      run: |
+        set -euo pipefail
+        if [ -z "${GALAXY_API_KEY:-}" ]; then
+          echo "GALAXY_API_KEY is not set; skipping Galaxy import."
+          exit 0
+        fi
+
+        ansible-galaxy role import \
+          --api-key "${GALAXY_API_KEY}" \
+          --role-name "${{ inputs.role-name }}" \
+          "${GITHUB_REPOSITORY_OWNER}" \
+          "${GITHUB_REPOSITORY#*/}"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,84 @@
+---
+name: Auto-tag on master
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-tag-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: Create version tag
+    runs-on: ubuntu-24.04
+    if: >-
+      !contains(github.event.head_commit.message, '[skip tag]')
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Skip if commit already has a tag
+        id: check
+        run: |
+          if git describe --exact-match --tags HEAD 2>/dev/null; then
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+            git describe --exact-match --tags HEAD
+          else
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Determine next version tag
+        if: steps.check.outputs.skip != 'true'
+        id: version
+        env:
+          INITIAL_TAG: v1.0.0
+        run: |
+          python3 <<'PY'
+          import os
+          import re
+          import subprocess
+
+          initial = os.environ["INITIAL_TAG"]
+
+          def parse_version(tag: str):
+              match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag)
+              if not match:
+                  return None
+              return tuple(int(value) for value in match.groups())
+
+          tags = subprocess.check_output(
+              ["git", "tag", "-l", "v*", "--sort=-v:refname"],
+              text=True,
+          ).strip().splitlines()
+
+          latest = next((tag for tag in tags if parse_version(tag)), None)
+          new_tag = initial if latest is None else None
+
+          if latest is not None:
+              major, minor, patch = parse_version(latest)
+              new_tag = f"v{major}.{minor}.{patch + 1}"
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
+              handle.write(f"tag={new_tag}\n")
+
+          print(f"Latest tag: {latest or 'none'}")
+          print(f"Next tag: {new_tag}")
+          PY
+
+      - name: Create and push tag
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.tag }}" \
+            -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,11 @@ jobs:
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade ansible-core ansible-lint yamllint
+          python -m pip install -r requirements-ci.txt
+
+      - name: Validate role metadata for Ansible Galaxy
+        run: |
+          python -m galaxy_importer.main --legacy-role --namespace steveyminecraft "${GITHUB_REPOSITORY#*/}"
 
       - name: Install Galaxy roles and collections
         run: ./scripts/install-ansible-collections.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Validate role metadata for Ansible Galaxy
         run: |
+          cd ..
           python -m galaxy_importer.main --legacy-role --namespace steveyminecraft "${GITHUB_REPOSITORY#*/}"
 
       - name: Install Galaxy roles and collections

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -1,0 +1,29 @@
+---
+name: Publish to Ansible Galaxy
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: galaxy-publish-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Import role
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Import role into Ansible Galaxy
+        uses: ./.github/actions/import-galaxy-role
+        env:
+          GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+---
+name: Release
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      publish-galaxy:
+        description: "Import the role into Ansible Galaxy"
+        default: true
+        required: false
+        type: boolean
+      galaxy-role-name:
+        description: "Galaxy role name"
+        default: docker-pihole
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+
+      - name: Import role into Ansible Galaxy
+        if: >-
+          github.event_name == 'workflow_dispatch' && inputs.publish-galaxy
+          || github.ref_type == 'tag'
+        uses: ./.github/actions/import-galaxy-role
+        with:
+          role-name: ${{ inputs.galaxy-role-name || 'docker-pihole' }}
+        env:
+          GALAXY_API_KEY: ${{ secrets.GALAXY_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ansible role to deploy [Pi-hole](https://pi-hole.net/) using Docker Compose on the target host. The role writes `docker-compose.yml`, pulls the image, manages optional firewalld rules, and can integrate with Unbound on a shared Docker network.
 
-Galaxy role: [`steveyminecraft.docker-pihole`](https://galaxy.ansible.com/ui/standalone/roles/steveyminecraft/docker-pihole/). Install into `roles/pihole` with:
+Galaxy role: [`steveyminecraft.docker-pihole`](https://galaxy.ansible.com/ui/standalone/roles/steveyminecraft/docker-pihole/) (`role_name` **`pihole`** in `meta/main.yml`; Galaxy listing name **`docker-pihole`**). Install into `roles/pihole` with:
 
 ```bash
 ansible-galaxy install steveyminecraft.docker-pihole,v1.0.0 -p roles --roles-path roles -f pihole

--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 Ansible role to deploy [Pi-hole](https://pi-hole.net/) using Docker Compose on the target host. The role writes `docker-compose.yml`, pulls the image, manages optional firewalld rules, and can integrate with Unbound on a shared Docker network.
 
-Galaxy `role_name` is **`pihole`** (`meta/main.yml`); this repository is commonly cloned as **`docker-pihole`** and referenced with `ANSIBLE_ROLES_PATH` so the role name matches the directory (see `tests/syntax-check.yml`).
+Galaxy role: [`steveyminecraft.docker-pihole`](https://galaxy.ansible.com/ui/standalone/roles/steveyminecraft/docker-pihole/). Install into `roles/pihole` with:
+
+```bash
+ansible-galaxy install steveyminecraft.docker-pihole,v1.0.0 -p roles --roles-path roles -f pihole
+```
+
+Or in `requirements.yml`: `src: steveyminecraft.docker-pihole`, `version: "1.0.0"`, `name: pihole`.
 
 ## Requirements
 
-- **Ansible**: 2.14 or newer (`meta/main.yml`).
+- **Ansible**: 2.20 or newer (`meta/main.yml`).
 - **Target host**: Docker Engine and **Docker Compose v2** (`docker compose` CLI). The role **does not** install Docker; install it beforehand (for example with your playbooks or another role).
 - **Collections**: install from `requirements.yml` (includes `ansible.posix` and `community.docker`), for example:
 
@@ -114,6 +120,22 @@ molecule test
 ```
 
 Molecule uses [`molecule/ansible.cfg`](molecule/ansible.cfg) (not the repo root `ansible.cfg`) so driver playbooks remain compatible with **Ansible 2.20+** strict conditionals.
+
+### Releases and Ansible Galaxy
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| [Auto-tag on master](.github/workflows/auto-tag.yml) | Push to `master` | Creates the next `v*.*.*` tag (starts at `v1.0.0`) |
+| [Publish to Ansible Galaxy](.github/workflows/galaxy-publish.yml) | Push to `master`, manual | Imports `steveyminecraft.docker-pihole` from the latest `master` commit |
+| [Release](.github/workflows/release.yml) | Tag `v*`, manual | GitHub release plus Galaxy import for that tag |
+
+Setup:
+
+1. Create a [Galaxy](https://galaxy.ansible.com) account linked to GitHub.
+2. Add repository secret **`GALAXY_API_KEY`** (Galaxy → Preferences → API Key).
+3. Merge to **`master`** — CI tags `v1.0.0` (then `v1.0.1`, …) and imports the role; tagged releases appear as installable versions (`ansible-galaxy install steveyminecraft.docker-pihole,v1.0.0`).
+
+Skip auto-tagging with `[skip tag]` in the commit message.
 
 ## License
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,21 +1,35 @@
 ---
 galaxy_info:
-  role_name: pihole
-  author: richardlaing00
-  description: Deploy Pi-hole using Docker
+  namespace: steveyminecraft
+  role_name: docker-pihole
+  author: steveyminecraft
+  description: Deploy Pi-hole using Docker (Pi-hole v6, optional Unbound upstream)
+  issue_tracker_url: https://github.com/steveyminecraft/docker-pihole/issues
+
   license: MIT
-  min_ansible_version: "2.14"
+
+  min_ansible_version: "2.20"
+  github_branch: master
   platforms:
     - name: Ubuntu
-      versions: ["all"]
+      versions:
+        - jammy
+        - noble
     - name: Debian
-      versions: ["all"]
+      versions:
+        - bookworm
+        - trixie
     - name: EL
-      versions: ["all"]
+      versions:
+        - "9"
+        - "10"
+
   galaxy_tags:
     - pihole
     - docker
     - dns
     - adblock
+    - unbound
+    - networking
 
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   namespace: steveyminecraft
-  role_name: docker-pihole
+  role_name: pihole
   author: steveyminecraft
   description: Deploy Pi-hole using Docker (Pi-hole v6, optional Unbound upstream)
   issue_tracker_url: https://github.com/steveyminecraft/docker-pihole/issues

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,4 @@
+ansible-core>=2.20,<2.21
+ansible-lint
+yamllint
+galaxy-importer


### PR DESCRIPTION
## Summary
- Add auto-tag on `master` (semver tags starting at `v1.0.0`)
- Publish `steveyminecraft.docker-pihole` to Ansible Galaxy on `master` push and on version tags
- Update Galaxy metadata (`namespace`, platforms, tags, ansible 2.20+)

## Test plan
- [ ] Add `GALAXY_API_KEY` repository secret before merge
- [ ] Merge to `master` and confirm `v1.0.0` tag is created
- [ ] Confirm Galaxy import succeeds and `steveyminecraft.docker-pihole,v1.0.0` installs
- [ ] Merge related `ansible-pihole` PR after this role version exists on Galaxy


Made with [Cursor](https://cursor.com)